### PR TITLE
Enhance viewer with Materialize styling

### DIFF
--- a/viewer/static/main.js
+++ b/viewer/static/main.js
@@ -33,16 +33,16 @@ async function loadWorkspaces() {
     const data = await res.json();
     const listDiv = document.getElementById('workspace-list');
     listDiv.innerHTML = '';
-    const ul = document.createElement('ul');
+    const collection = document.createElement('div');
+    collection.className = 'collection';
     data.workspaces.forEach(name => {
-        const li = document.createElement('li');
-        const link = document.createElement('a');
-        link.href = '/workspace/' + name;
-        link.textContent = name;
-        li.appendChild(link);
-        ul.appendChild(li);
+        const item = document.createElement('a');
+        item.href = '/workspace/' + name;
+        item.textContent = name;
+        item.className = 'collection-item';
+        collection.appendChild(item);
     });
-    listDiv.appendChild(ul);
+    listDiv.appendChild(collection);
 }
 
 function quaternionToMatrix(qw, qx, qy, qz) {

--- a/viewer/templates/index.html
+++ b/viewer/templates/index.html
@@ -3,16 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <title>COLMAP Viewer</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
     <style>
-        body { font-family: Arial, sans-serif; }
-        #workspace-list { margin-bottom: 1em; }
+        #workspace-list { margin-top: 2em; }
     </style>
 </head>
-<body>
-    <h1>COLMAP Viewer</h1>
-    <div id="workspace-list"></div>
+<body class="container">
+    <h3 class="center-align">COLMAP Viewer</h3>
+    <div id="workspace-list" class="collection"></div>
     <script src="https://cdn.jsdelivr.net/npm/three@0.135.0/build/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.135.0/examples/js/controls/OrbitControls.js"></script>
     <script src="/static/main.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/viewer/templates/viewer.html
+++ b/viewer/templates/viewer.html
@@ -3,21 +3,25 @@
 <head>
     <meta charset="UTF-8">
     <title>Workspace {{ name }}</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
     <style>
-        body { font-family: Arial, sans-serif; }
         canvas { width: 100%; height: 80vh; display: block; }
     </style>
 </head>
-<body>
-    <h1>Workspace: {{ name }}</h1>
-    <div id="viewer"></div>
-    <div>
-        <label>Point Size:
-            <input type="range" id="point-size" min="0.001" max="0.05" step="0.001" value="0.01">
-        </label>
-        <label>Camera Size:
-            <input type="range" id="camera-size" min="0.005" max="0.1" step="0.005" value="0.02">
-        </label>
+<body class="container">
+    <h3 class="center-align">Workspace: {{ name }}</h3>
+    <div id="viewer" class="card"></div>
+    <div class="section">
+        <div class="row">
+            <div class="col s12 m6">
+                <label for="point-size">Point Size</label>
+                <input type="range" id="point-size" min="0.001" max="0.05" step="0.001" value="0.01">
+            </div>
+            <div class="col s12 m6">
+                <label for="camera-size">Camera Size</label>
+                <input type="range" id="camera-size" min="0.005" max="0.1" step="0.005" value="0.02">
+            </div>
+        </div>
     </div>
     <script>
         const WORKSPACE = "{{ name }}";
@@ -25,5 +29,6 @@
     <script src="https://cdn.jsdelivr.net/npm/three@0.135.0/build/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.135.0/examples/js/controls/OrbitControls.js"></script>
     <script src="/static/main.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- switch index and viewer templates to Materialize CSS
- use Materialize collection for workspace list
- adjust JS to create Materialize list items

## Testing
- `python -m py_compile viewer/app.py`
- `python -m py_compile viewer/workspace_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_6847e15f4a0883298593bb00798f0ee0